### PR TITLE
support DLL builds on windows with visual studio compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,24 @@ set(OSI_PROTO_FILES
     osi_sensorview.proto
     osi_worldinterface.proto
 )
+include_directories(./)
+protobuf_generate_cpp(PROTO_SRCS PROTO_HEADERS ${OSI_PROTO_FILES} EXPORT_MACRO "OSI_EXPORT")
+if(MSVC)
+add_compile_options( /FIOSIExport.h)
+add_definitions(-DPROTOBUF_USE_DLLS)
+else(MSVC)
+add_compile_options( -include OSIExport.h)
+endif(MSVC)
 
-protobuf_generate_cpp(PROTO_SRCS PROTO_HEADERS ${OSI_PROTO_FILES})
+
+add_library(${PROJECT_NAME} SHARED ${PROTO_SRCS} ${PROTO_HEADERS})
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        ${PROTOBUF_INCLUDE_DIR}
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
+)
+
 
 add_library(${PROJECT_NAME}_static STATIC ${PROTO_SRCS} ${PROTO_HEADERS})
 target_include_directories(${PROJECT_NAME}_static
@@ -88,6 +104,8 @@ target_include_directories(${PROJECT_NAME}_static
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
         $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
 )
+
+target_compile_definitions(${PROJECT_NAME}_static PUBLIC -DNODLL)
 target_link_libraries(${PROJECT_NAME}_static PUBLIC ${PROTOBUF_LIBRARY})
 install(TARGETS ${PROJECT_NAME}_static
         EXPORT ${PROJECT_NAME}_targets
@@ -102,6 +120,7 @@ target_include_directories(${PROJECT_NAME}_obj
         $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
 )
 set_property(TARGET ${PROJECT_NAME}_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(${PROJECT_NAME}_obj PUBLIC -DNODLL)
 
 
 add_library(${PROJECT_NAME}_pic STATIC $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
@@ -120,13 +139,6 @@ install(TARGETS ${PROJECT_NAME}_pic
         EXPORT ${PROJECT_NAME}_targets
         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
 
-add_library(${PROJECT_NAME} SHARED $<TARGET_OBJECTS:${PROJECT_NAME}_obj>)
-target_include_directories(${PROJECT_NAME}
-    PUBLIC
-        ${PROTOBUF_INCLUDE_DIR}
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-        $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
-)
 
 set_property(
     TARGET ${PROJECT_NAME}

--- a/OSIExport.h
+++ b/OSIExport.h
@@ -1,0 +1,24 @@
+#ifndef OSIEXPORT_H
+#define OSIEXPORT_H
+
+#if defined(_WIN32) && !defined(NODLL)
+#define OSIIMPORT __declspec(dllimport)
+#define OSIEXPORT __declspec(dllexport)
+
+#elif (defined(__GNUC__) && __GNUC__ >= 4 || defined(__clang__))
+#define OSIEXPORT __attribute__((visibility("default")))
+#define OSIIMPORT OSIEXPORT
+
+#else
+#define OSIIMPORT
+#define OSIEXPORT
+#endif
+
+#if defined(open_simulation_interface_EXPORTS)
+#define OSI_EXPORT OSIEXPORT
+#else
+#define OSI_EXPORT OSIIMPORT
+#endif
+
+
+#endif  // OSIEXPORT_H


### PR DESCRIPTION
Static libraries don't work in OpenPASS as protobuff message types would be registered multiple times for every dll which is loaded during runtime.
DLL build was broken on windows with msvc compilers as no symbols where exported.
This commit adds dllexport statements.
You have to include OSIExport.h before including any of the osi header files.
unfortunately this can't be done automatically in the generated .pb,h files
The proposed changes should work on linux and macOS also.

#### Reference to a related issue in the repository
Add a reference to a related issue in the repository.

#### Add a description
Add a description of the changes proposed in the pull request.

**Some questions to ask**:
What is this change?
What does it fix?
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
How has it been tested?

#### Mention a member
Add @mentions of the person or team responsible for reviewing proposed changes.

#### Check the checklist

- [ ] My code and comments follow the [style guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/commenting.html) and [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.